### PR TITLE
Tests showing transition behavior

### DIFF
--- a/src/tests/SuspenseTriggerOnTransitionUpdateComponent.test.tsx
+++ b/src/tests/SuspenseTriggerOnTransitionUpdateComponent.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { renderAndHydrate } from "./reactRendering";
-import React, { Suspense, lazy, useState, useTransition } from "react";
+import React, {Suspense, lazy, useState, useTransition, startTransition, memo, useEffect} from "react";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const resetLazyCache = () => {
@@ -19,7 +19,7 @@ let LazyChild = lazy(() =>
   })),
 );
 
-const SuspenseTriggerOnTransitionUpdateComponent: React.FC = () => {
+const SuspenseTriggerOnUseTransitionUpdateComponent: React.FC = () => {
   const [counter, setCounter] = useState(0);
   const [isPending, startTransition] = useTransition();
 
@@ -28,7 +28,7 @@ const SuspenseTriggerOnTransitionUpdateComponent: React.FC = () => {
       setCounter((prev) => prev + 1);
     });
   };
-
+  
   return (
     <div>
       <button onClick={handleIncrementCounter}>
@@ -43,13 +43,70 @@ const SuspenseTriggerOnTransitionUpdateComponent: React.FC = () => {
   );
 };
 
+const ChildThatSuspends = React.FB = memo(() => {
+    return (
+        <Suspense fallback={<p>Suspended</p>}>
+            <p>Not Suspended</p>
+            <LazyChild />
+        </Suspense>
+    )
+});
+
+const SuspenseTriggerOnUseTransitionUpdateMemoComponent: React.FC = () => {
+    const [counter, setCounter] = useState(0);
+    const [isPending, startTransition] = useTransition();
+
+    const handleIncrementCounter = () => {
+        startTransition(() => {
+            setCounter((prev) => prev + 1);
+        });
+    };
+
+    return (
+        <div>
+            <button onClick={handleIncrementCounter}>
+                Counter: {counter} {isPending && "(pending)"}
+            </button>
+
+           <ChildThatSuspends />
+        </div>
+    );
+};
+
+
+
+const SuspenseTriggerOnTransitionUpdateComponent: React.FC = () => {
+    const [counter, setCounter] = useState(0);
+
+    const handleIncrementCounter = () => {
+        startTransition(() => {
+            setCounter((prev) => prev + 1);
+        });
+    };
+    return (
+        <div>
+            <button onClick={handleIncrementCounter}>
+                Counter: {counter}
+            </button>
+
+            <Suspense fallback={<p>Suspended</p>}>
+                <p>Not Suspended</p>
+                <LazyChild />
+            </Suspense>
+        </div>
+    );
+};
+
+beforeEach(() => {
+    resetLazyCache();
+})
 afterEach(() => {
   document.body.innerHTML = "";
 });
 
-test("transition-wrapped state change still triggers Suspense fallback during React 18 lazy hydration", async () => {
+test("useTransition-wrapped state change will triggers Suspense fallback during React 18 lazy hydration if pending flows in", async () => {
   // Step 1: Render and hydrate component using helper
-  await renderAndHydrate(<SuspenseTriggerOnTransitionUpdateComponent />, () =>
+  await renderAndHydrate(<SuspenseTriggerOnUseTransitionUpdateComponent />, () =>
     resetLazyCache(),
   );
 
@@ -70,7 +127,69 @@ test("transition-wrapped state change still triggers Suspense fallback during Re
   // Verify counter incremented and shows pending state
   expect(counterButton).toHaveTextContent("Counter: 1");
 
-  // Step 3: Verify suspense fallback is STILL triggered even with startTransition
-  // During hydration, transitions don't prevent Suspense fallbacks when lazy components are loading
+  // Step 3: Verify suspense fallback IS triggered, because the sync update for isPending
+  // flows into the suspended boundary un-memoized, forcing the fallback to be shown.
+  // During hydration, will otherwise prevent Suspense fallbacks when lazy components are loading.
   expect(await screen.findByText("Suspended")).toBeInTheDocument();
+});
+
+test("useTransition-wrapped state change does not trigger Suspense fallback if memo'd during React 18 lazy hydration", async () => {
+    // Step 1: Render and hydrate component using helper
+    await renderAndHydrate(<SuspenseTriggerOnUseTransitionUpdateMemoComponent />, () =>
+        resetLazyCache(),
+    );
+
+    // Verify initial SSR state - counter button should be rendered
+    expect(screen.getByRole("button")).toHaveTextContent("Counter: 0");
+    // SSR should show non-suspended content initially
+    expect(await screen.findAllByText("Not Suspended")).toHaveLength(1);
+
+    // Wait for hydration to complete
+    await waitFor(() => {
+        expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    // Step 2: Click the counter button to trigger transition-wrapped state change
+    const counterButton = screen.getByRole("button");
+    expect(counterButton).toHaveTextContent("Counter: 0");
+    fireEvent.click(counterButton);
+    
+    // Verify counter incremented and shows pending state
+    expect(counterButton).toHaveTextContent("Counter: 1");
+
+    // Step 3: Verify suspense fallback is NOT triggered with startTransition.
+    // During hydration, transitions prevent Suspense fallbacks when lazy components are loading,
+    // Unless a synchronous update (such as the isPending update for useTransition),
+    // flows into the boundary without being memoized.
+    expect(await screen.findByText("Not Suspended")).toBeInTheDocument();
+});
+
+test("startTransition-wrapped state change does not trigger Suspense fallback during React 18 lazy hydration", async () => {
+    // Step 1: Render and hydrate component using helper
+    await renderAndHydrate(<SuspenseTriggerOnTransitionUpdateComponent />, () =>
+        resetLazyCache(),
+    );
+
+    // Verify initial SSR state - counter button should be rendered
+    expect(screen.getByRole("button")).toHaveTextContent("Counter: 0");
+    // SSR should show non-suspended content initially
+    expect(await screen.findAllByText("Not Suspended")).toHaveLength(1);
+
+    // Wait for hydration to complete
+    await waitFor(() => {
+        expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    // Step 2: Click the counter button to trigger transition-wrapped state change
+    const counterButton = screen.getByRole("button");
+    fireEvent.click(counterButton);
+
+    // Verify counter not incremented
+    expect(counterButton).toHaveTextContent("Counter: 0");
+
+    // Step 3: Verify suspense fallback is NOT triggered with startTransition.
+    // During hydration, transitions prevent Suspense fallbacks when lazy components are loading,
+    // Unless a synchronous update (such as the isPending update for useTransition),
+    // flows into the boundary without being memoized.
+    expect(await screen.findByText("Not Suspended")).toBeInTheDocument();
 });


### PR DESCRIPTION
_note: just submitting this to show the behavior, not intending to merge it_


## Overview

The tests and notes in this repo that say things to the effect of:

> transitions don't prevent Suspense fallbacks when lazy components are loading

This is incorrect. I added two tests here to show the correct behavior.

Updates in a transition do prevent Suspense fallbacks from being shown in dehydrated trees. 

## So why do the current tests show fallbacks?

The reason the current tests show the fallback is that there is a sync update, and then a transition update. Specifically, the `useTransition` hook will first trigger a synchronous render to commit the pending state, and then perform the scheduled update in a transition.

The tests likely forgot about this case because they never assert that the pending count is committed, I think if they did it would have been more obvious what was happening.

## New tests

The new tests I added show that if you use `React.startTransition`, or wrap the children in `React.memo`, the fallback is not shown because in the former case there's no sync `isPending` update and in the latter the sync update doesn't flow into the boundary due to memoization.

I didn't write a test for it, but the fallback also would not be shown if this was using React Compiler.
