### PR TITLE
React Compiler's memoization prevents fallbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
+    "@types/node": "^24.3.1",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
-    "@types/node": "^24.3.1",
     "@vitejs/plugin-react": "^5.0.2",
+    "babel-plugin-react-compiler": "19.1.0-rc.3",
     "happy-dom": "^18.0.1",
     "typescript": "^5.9.2",
     "vite": "^7.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       "@vitejs/plugin-react":
         specifier: ^5.0.2
         version: 5.0.2(vite@7.1.5(@types/node@24.3.1))
+      babel-plugin-react-compiler:
+        specifier: 19.1.0-rc.3
+        version: 19.1.0-rc.3
       happy-dom:
         specifier: ^18.0.1
         version: 18.0.1
@@ -841,6 +844,12 @@ packages:
         integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
       }
     engines: { node: ">=12" }
+
+  babel-plugin-react-compiler@19.1.0-rc.3:
+    resolution:
+      {
+        integrity: sha512-mjRn69WuTz4adL0bXGx8Rsyk1086zFJeKmes6aK0xPuK3aaXmDJdLHqwKKMrpm6KAI1MCoUK72d2VeqQbu8YIA==,
+      }
 
   browserslist@4.25.4:
     resolution:
@@ -1855,6 +1864,10 @@ snapshots:
       dequal: 2.0.3
 
   assertion-error@2.0.1: {}
+
+  babel-plugin-react-compiler@19.1.0-rc.3:
+    dependencies:
+      "@babel/types": 7.28.4
 
   browserslist@4.25.4:
     dependencies:

--- a/src/tests/SuspenseTriggerOnAsyncStateAfterAwaitComponent.test.tsx
+++ b/src/tests/SuspenseTriggerOnAsyncStateAfterAwaitComponent.test.tsx
@@ -73,7 +73,7 @@ test("state updates after await lose transition context and trigger Suspense fal
   // Step 3: Verify suspense fallback is triggered due to async context loss
   // State updates after await lose the transition context and behave like sync updates
   expect(
-    await screen.findByText("Suspense Boundary Fallback"),
+    await screen.findByText("Suspense Boundary Content"),
   ).toBeInTheDocument();
 
   await sleep(100);

--- a/src/tests/SuspenseTriggerOnCorrectlyWrappedAsyncUseTransitionComponent.test.tsx
+++ b/src/tests/SuspenseTriggerOnCorrectlyWrappedAsyncUseTransitionComponent.test.tsx
@@ -70,6 +70,6 @@ test("correctly wrapped async useTransition still triggers Suspense fallback dur
   // Step 3: Even with proper wrapping, useTransition's startTransition still triggers fallbacks
   // There's a difference between direct startTransition import vs useTransition hook during hydration
   expect(
-    await screen.findByText("Suspense Boundary Fallback"),
+    await screen.findByText("Suspense Boundary Content"),
   ).toBeInTheDocument();
 });

--- a/src/tests/SuspenseTriggerOnDeferredValueComponent.test.tsx
+++ b/src/tests/SuspenseTriggerOnDeferredValueComponent.test.tsx
@@ -65,7 +65,7 @@ test("state change with useDeferredValue triggers Suspense fallback during React
 
   // Step 3: Verify suspense fallback is triggered by state change
   expect(
-    await screen.findByText("Suspense Boundary Fallback"),
+    await screen.findByText("Suspense Boundary Content"),
   ).toBeInTheDocument();
 });
 

--- a/src/tests/SuspenseTriggerOnExternalStoreComponent.test.tsx
+++ b/src/tests/SuspenseTriggerOnExternalStoreComponent.test.tsx
@@ -95,6 +95,6 @@ test("external store change triggers Suspense fallback during React 18 lazy hydr
   // Step 3: Verify suspense fallback is triggered by external store change
   // External store mutations cannot be marked as non-blocking transitions
   expect(
-    await screen.findByText("Suspense Boundary Fallback"),
+    await screen.findByText("Suspense Boundary Content"),
   ).toBeInTheDocument();
 });

--- a/src/tests/SuspenseTriggerOnIsPendingRenderComponent.test.tsx
+++ b/src/tests/SuspenseTriggerOnIsPendingRenderComponent.test.tsx
@@ -70,6 +70,6 @@ test("rendering isPending state triggers Suspense fallback even within startTran
   // Step 3: Verify suspense fallback is triggered despite startTransition
   // This happens because rendering isPending state breaks the transition optimization
   expect(
-    await screen.findByText("Suspense Boundary Fallback"),
+    await screen.findByText("Suspense Boundary Content"),
   ).toBeInTheDocument();
 });

--- a/src/tests/SuspenseTriggerOnReducerChangeComponent.test.tsx
+++ b/src/tests/SuspenseTriggerOnReducerChangeComponent.test.tsx
@@ -76,6 +76,6 @@ test("reducer change triggers Suspense fallback during React 18 lazy hydration",
 
   // Step 3: Verify suspense fallback is triggered by reducer change
   expect(
-    await screen.findByText("Suspense Boundary Fallback"),
+    await screen.findByText("Suspense Boundary Content"),
   ).toBeInTheDocument();
 });

--- a/src/tests/SuspenseTriggerOnStateChangeComponent.test.tsx
+++ b/src/tests/SuspenseTriggerOnStateChangeComponent.test.tsx
@@ -59,7 +59,7 @@ test("state change triggers Suspense fallback during React 18 lazy hydration", a
 
   // Step 3: Verify suspense fallback is triggered by state change
   expect(
-    await screen.findByText("Suspense Boundary Fallback"),
+    await screen.findByText("Suspense Boundary Content"),
   ).toBeInTheDocument();
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react({ babel: { plugins: ["babel-plugin-react-compiler"] } })],
   test: {
     globals: true,
     environment: "happy-dom",


### PR DESCRIPTION
This is not meant to be merged as is, just sharing the findings that with memoization by React Compiler enabled it seems to pass all the tests 🤯 